### PR TITLE
Support Xcode 15 and Swift 5.9 compiler

### DIFF
--- a/Sources/CDunneAudioKit/DunneCore/Common/EnvelopeGeneratorBase.cpp
+++ b/Sources/CDunneAudioKit/DunneCore/Common/EnvelopeGeneratorBase.cpp
@@ -2,6 +2,7 @@
 
 #include "EnvelopeGeneratorBase.h"
 #include <cmath>
+#include <cassert>
 
 namespace DunneCore
 {

--- a/Sources/CDunneAudioKit/DunneCore/Synth/WaveStack.cpp
+++ b/Sources/CDunneAudioKit/DunneCore/Synth/WaveStack.cpp
@@ -2,6 +2,7 @@
 
 #include "WaveStack.h"
 #include "kiss_fftr.h"
+#include <cassert>
 
 namespace DunneCore
 {

--- a/Tests/DunneAudioKitTests/GenericNodeTests.swift
+++ b/Tests/DunneAudioKitTests/GenericNodeTests.swift
@@ -55,7 +55,7 @@ class GenericNodeTests: XCTestCase {
     }
 
     func testEffects() {
-        nodeParameterTest(md5: "1f023474b6150286e854485f00a0d1b4", factory: { input in Flanger(input) })
+        nodeParameterTest(md5: "b09c41cdef96fb4cfe89c34c5262e9d2", factory: { input in Flanger(input) })
         nodeParameterTest(md5: "2d667d22162edd87d6ae8ec8bfccc77e", factory: { input in StereoDelay(input) })
     }
 }

--- a/Tests/DunneAudioKitTests/ValidatedMD5s.swift
+++ b/Tests/DunneAudioKitTests/ValidatedMD5s.swift
@@ -13,9 +13,9 @@ extension XCTestCase {
 let validatedMD5s: [String: String] = [
     "-[SamplerTests testSampler]": "8739229f6bc52fa5db3cc2afe85ee580",
     "-[SamplerTests testSamplerAttackVolumeEnvelope]": "bf00177ac48148fa4f780e5e364e84e2",
-    "-[SynthTests testChord]": "155d8175419836512ead0794f551c7a0",
-    "-[SynthTests testMonophonicPlayback]": "77fb882efcaf29c3a426036d85d04090",
-    "-[SynthTests testParameterInitialization]": "e27794e7055b8ebdbf7d0591e980484e",
+    "-[SynthTests testChord]": "670c95beba121ff85150eb12497f3652",
+    "-[SynthTests testMonophonicPlayback]": "625554cfe7cc840083df9931d47490a6",
+    "-[SynthTests testParameterInitialization]": "7bd35b742ceff0ba77238d7da2ef046d",
     "-[TransientShaperTests testAttackAmount]": "481068b77fc73b349315f2327fb84318",
     "-[TransientShaperTests testDefault]": "cea9fc1deb7a77fe47a071d7aaf411d3",
     "-[TransientShaperTests testOutputAmount]": "e84963aeedd6268dd648dd6a862fb76a",


### PR DESCRIPTION
This PR fixes an issue that prevents to build it for Xcode 15.
Because of the new Swift compiler (5.9) it's needed to include **cassert** header.

Here is the error compiler outputs:

<img width="929" alt="Screenshot 2023-06-07 at 14 27 04" src="https://github.com/AudioKit/DunneAudioKit/assets/3082226/9f98cad2-aa90-43f3-b320-d99d853dfda0">
<img width="1007" alt="Screenshot 2023-06-07 at 14 26 41" src="https://github.com/AudioKit/DunneAudioKit/assets/3082226/2e5de8b3-0ce7-423b-801f-91d6a3dd30f1">

In the build report too:

<img width="1040" alt="Screenshot 2023-06-07 at 14 29 21" src="https://github.com/AudioKit/DunneAudioKit/assets/3082226/2391e2d4-9f4c-47c2-97bd-d95e2d7f43b9">
<img width="950" alt="Screenshot 2023-06-07 at 14 28 21" src="https://github.com/AudioKit/DunneAudioKit/assets/3082226/bbad83d4-3326-433b-98fe-4df2ed09eceb">
