### PR TITLE
Increase minimum delay time in StereoDelay.cpp

### DIFF
--- a/Sources/CDunneAudioKit/DunneCore/Modulated Delay/StereoDelay.cpp
+++ b/Sources/CDunneAudioKit/DunneCore/Modulated Delay/StereoDelay.cpp
@@ -30,8 +30,8 @@ namespace DunneCore
 
     void StereoDelay::setDelayMs(double delayMs)
     {
-        delayLine1.setDelayMs(delayMs);
-        delayLine2.setDelayMs(delayMs);
+        delayLine1.setDelayMs(fmax(1.0, delayMs));
+        delayLine2.setDelayMs(fmax(1.0, delayMs));
     }
 
     void StereoDelay::setFeedback(float fraction)


### PR DESCRIPTION
When the delay time is set to 0 the observed delay time is 1 second. This PR prevents that value from ever going to 0 while keeping the AUParameter values unchanged.