### PR TITLE
Reading of SFZ improved: loop_mode=no_loop, fixes #21

### DIFF
--- a/Sources/DunneAudioKit/Sampler+SFZ.swift
+++ b/Sources/DunneAudioKit/Sampler+SFZ.swift
@@ -90,7 +90,7 @@ extension SamplerData {
                                                             maximumNoteNumber: Int32(highNoteNumber),
                                                             minimumVelocity: Int32(lowVelocity),
                                                             maximumVelocity: Int32(highVelocity),
-                                                            isLooping: loopMode != "",
+                                                            isLooping: loopMode != "no_loop",
                                                             loopStartPoint: loopStartPoint,
                                                             loopEndPoint: loopEndPoint,
                                                             startPoint: 0.0,

--- a/Sources/DunneAudioKit/Sampler+SFZ.swift
+++ b/Sources/DunneAudioKit/Sampler+SFZ.swift
@@ -30,7 +30,7 @@ extension SamplerData {
         var lowVelocity: MIDIVelocity = 0
         var highVelocity: MIDIVelocity = 127
         var sample = ""
-        var loopMode = ""
+        var loopMode = "no_loop"
         var loopStartPoint: Float32 = 0
         var loopEndPoint: Float32 = 0
 


### PR DESCRIPTION
Improved reading of SFZ files:
-  loop_mode=no_loop will no longer loop the sample

https://sfzformat.com/opcodes/loop_mode/
