### PR TITLE
Fix Xcode 26 compatibility: replace NULL with nullptr in SampleOscillator

### DIFF
--- a/Sources/CDunneAudioKit/DunneCore/Sampler/SampleOscillator.h
+++ b/Sources/CDunneAudioKit/DunneCore/Sampler/SampleOscillator.h
@@ -20,7 +20,7 @@ namespace DunneCore
         // return true if we run out of samples
         inline bool getSample(SampleBuffer *sampleBuffer, int sampleCount, float *output, float gain)
         {
-            if (sampleBuffer == NULL || indexPoint > sampleBuffer->endPoint) return true;
+            if (sampleBuffer == nullptr || indexPoint > sampleBuffer->endPoint) return true;
             *output = sampleBuffer->interp(indexPoint, gain);
             
             indexPoint += multiplier * increment;
@@ -35,7 +35,7 @@ namespace DunneCore
         // return true if we run out of samples
         inline bool getSamplePair(SampleBuffer *sampleBuffer, int sampleCount, float *leftOutput, float *rightOutput, float gain)
         {
-            if (sampleBuffer == NULL || indexPoint > sampleBuffer->endPoint) return true;
+            if (sampleBuffer == nullptr || indexPoint > sampleBuffer->endPoint) return true;
             sampleBuffer->interp(indexPoint, leftOutput, rightOutput, gain);
             
             indexPoint += multiplier * increment;


### PR DESCRIPTION
## Summary
- Replace `NULL` with C++ `nullptr` in `SampleOscillator.h`
- [Xcode 26.4](https://developer.apple.com/documentation/xcode-release-notes/xcode-26_4-release-notes#C++-Standard-Library) stricter headers no longer implicitly provide `NULL` via `<math.h>`

## Test plan
- [x] `swift build` compiles successfully